### PR TITLE
TASK: Implement match exclude patterns

### DIFF
--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -39,6 +39,12 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
     protected $uriPathPropertyName;
 
     /**
+     * @Flow\InjectConfiguration(path="matchExcludePatterns")
+     * @var array
+     */
+    protected $matchExcludePatterns;
+
+    /**
      * Builds a node path which matches the given request path.
      *
      * This method loos for nodes with the configured uriPathPropertyName property having a matching value.
@@ -118,6 +124,13 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
         // Custom check if request path is a backend request and skip further matching.
         if ($requestPath === 'neos' || strpos($requestPath, 'neos/') === 0) {
             throw new Exception\NoSuchNodeException(sprintf('No match possible because "%s" is a backend request path', $requestPath), 1512649661);
+        }
+
+        //check for exclude patterns and skip further matching
+        foreach ($this->matchExcludePatterns as $exclude) {
+            if (strpos($requestPath, $exclude) === 0) {
+                throw new Exception\NoSuchNodeException(sprintf('Request paths starting with "%s" are excluded for path matching - path: %s', $exclude, $requestPath), 1515959518);
+            }
         }
 
         return parent::convertRequestPathToNode($requestPath);

--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -126,7 +126,7 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
             throw new Exception\NoSuchNodeException(sprintf('No match possible because "%s" is a backend request path', $requestPath), 1512649661);
         }
 
-        //check for exclude patterns and skip further matching
+        // Check for exclude patterns and skip further matching
         foreach ($this->matchExcludePatterns as $exclude) {
             if (strpos($requestPath, $exclude) === 0) {
                 throw new Exception\NoSuchNodeException(sprintf('Request paths starting with "%s" are excluded for path matching - path: %s', $exclude, $requestPath), 1515959518);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,3 +2,5 @@ Flownative:
   Neos:
     CustomDocumentUriRouting:
       uriPathPropertyName: 'uriPath'
+      matchExcludePatterns:
+        - '_Resources'


### PR DESCRIPTION
In order to exclude specific request paths (eg. public resources), this introduces a new setting.
All given array values will skip the matching process for request paths that start with the value.
The default shipped with the package is:

    Neos:
      CustomDocumentUriRouting:
        matchExcludePatterns:
          - '_Resources'

Any URI starting with `_Resources` will be ignored by the package and passed through.