### PR TITLE
BUGFIX: Only flush route cache for relevant changes

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -38,7 +38,7 @@ class Package extends BasePackage
             }
 
             $uriPathPropertyName = $bootstrap->getObjectManager()->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Flownative.Neos.CustomDocumentUriRouting.uriPathPropertyName');
-            if ($propertyName !== $uriPathPropertyName || empty($newValue)) {
+            if ($propertyName !== $uriPathPropertyName) {
                 return;
             }
 

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -42,15 +42,17 @@ class Package extends BasePackage
                 return;
             }
 
-            $q = new FlowQuery([$node->getContext()->getCurrentSiteNode()]);
-            $q = $q->context(['invisibleContentShown' => true, 'removedContentShown' => true, 'inaccessibleContentShown' => true]);
+            if (!empty($newValue)) {
+                $q = new FlowQuery([$node->getContext()->getCurrentSiteNode()]);
+                $q = $q->context(['invisibleContentShown' => true, 'removedContentShown' => true, 'inaccessibleContentShown' => true]);
 
-            $possibleUriPath = $initialUriPath = $newValue;
-            $i = 1;
-            while ($q->find(sprintf('[instanceof Neos.Neos:Document][%s="%s"]', $propertyName, $possibleUriPath))->count() > 0) {
-                $possibleUriPath = $initialUriPath . '-' . $i++;
+                $possibleUriPath = $initialUriPath = $newValue;
+                $i = 1;
+                while ($q->find(sprintf('[instanceof Neos.Neos:Document][%s="%s"]', $propertyName, $possibleUriPath))->count() > 0) {
+                    $possibleUriPath = $initialUriPath . '-' . $i++;
+                }
+                $node->setProperty($propertyName, $possibleUriPath);
             }
-            $node->setProperty($propertyName, $possibleUriPath);
 
             $bootstrap->getObjectManager()->get(RouteCacheFlusher::class)->registerNodeChange($node);
         });


### PR DESCRIPTION
Adjusts the `nodePropertyChanged` slot to only flush the
`RouteCache` if the following conditions are met:

* The modified node is a `Document` node
* The name of the changed property is equal to the configured `uriPathPropertyName`

Fixes: #5