### PR TITLE
Provide hotfix for Neos core performance issue

### DIFF
--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -11,7 +11,9 @@ namespace Flownative\Neos\CustomDocumentUriRouting\Routing;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeData;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
 use Neos\ContentRepository\Domain\Utility\NodePaths;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
@@ -50,6 +52,12 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
      * @var array
      */
     protected $matchExcludePatterns;
+
+    /**
+     * @Flow\Inject
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
 
     /**
      * Builds a node path which matches the given request path.


### PR DESCRIPTION
This change provides a hotfix to mitigate a performance issue in the
original implementation of the Frontend Node Route Part Handler in
Neos core. When a given document node contains thousands of child nodes,
the original route part handler may end up loading all of these nodes
into memory in order to check their URI path segment.

The fix is provided as part of this package for convenience until the
issue is resolved in Neos core and has been released.