### PR TITLE
TASK: relax version constraints to support Neos 5 & 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,34 @@
     "description": "This allows to have custom document URI paths for document nodes",
     "license": "MIT",
     "require": {
-        "neos/neos": "^3.0 || ^4.0"
+        "neos/neos": "^3.0 || ^4.0 || ^5.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {
             "Flownative\\Neos\\CustomDocumentUriRouting\\": "Classes"
         }
+    },
+    "extra": {
+        "applied-flow-migrations": [
+            "TYPO3.Form-20160601101500",
+            "Neos.Twitter.Bootstrap-20161124204912",
+            "Neos.Form-20161124205254",
+            "Neos.Party-20161124225257",
+            "Neos.Imagine-20161124231742",
+            "Neos.SwiftMailer-20161130105617",
+            "Neos.ContentRepository.Search-20161210231100",
+            "Neos.Seo-20170127154600",
+            "Neos.Flow-20180415105700",
+            "Neos.Neos-20180907103800",
+            "Neos.Neos.Ui-20190319094900",
+            "Neos.Flow-20190425144900",
+            "Neos.Flow-20190515215000",
+            "Flowpack.ElasticSearch.ContentRepositoryAdaptor-20200513223401",
+            "Neos.Flow-20200813181400",
+            "Neos.Flow-20201003165200",
+            "Neos.Flow-20201109224100",
+            "Neos.Flow-20201205172733",
+            "Neos.Flow-20201207104500"
+        ]
     }
 }


### PR DESCRIPTION
The package works just fine, without any further changes.

Also #13 seems not an issue anymore since Neos 5. On copy&paste the newly created document remains focused and is editable, thus the uriPath property can be edited manually. However, clearing or updating the property to a unique value might be better.